### PR TITLE
Create social distancing aggregate tables

### DIFF
--- a/social_distancing/init_trips_by_county.sql
+++ b/social_distancing/init_trips_by_county.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS sg_trips_by_county (
     trips int
 );
 
-CREATE TABLE IF NOT EXISTS sg_trips_days_included (
+CREATE TABLE IF NOT EXISTS county_days_included (
     year_week text,
     date text
 );

--- a/social_distancing/init_trips_by_county.sql
+++ b/social_distancing/init_trips_by_county.sql
@@ -4,3 +4,8 @@ CREATE TABLE IF NOT EXISTS sg_trips_by_county (
     destination text,
     trips int
 );
+
+CREATE TABLE IF NOT EXISTS sg_trips_days_included (
+    year_week text,
+    date text
+);

--- a/social_distancing/init_trips_by_county.sql
+++ b/social_distancing/init_trips_by_county.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS sg_trips_by_county (
+    year_week text,
+    origin text,
+    destination text,
+    trips int
+);

--- a/social_distancing/init_trips_by_state.sql
+++ b/social_distancing/init_trips_by_state.sql
@@ -3,8 +3,7 @@ CREATE TABLE IF NOT EXISTS sg_trips_by_state (
     state text,
     to_nyc int,
     from_nyc int,
-    net_nyc int,
-    state_geom geometry(Geometry,4326)
+    net_nyc int
 );
 
 CREATE TABLE IF NOT EXISTS state_days_included (

--- a/social_distancing/init_trips_by_state.sql
+++ b/social_distancing/init_trips_by_state.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS sg_trips_by_state (
+    year_week text,
+    state text,
+    to_nyc int,
+    from_nyc int,
+    net_nyc int,
+    state_geom geometry(Geometry,4326)
+);
+
+CREATE TABLE IF NOT EXISTS state_days_included (
+    year_week text,
+    date text
+);

--- a/social_distancing/trips_by_county.sql
+++ b/social_distancing/trips_by_county.sql
@@ -9,7 +9,7 @@ DECLARE
 
 BEGIN
     SELECT to_char(current_setting('myvars.date')::date, 'IYYY-IW') NOT IN (SELECT DISTINCT year_week FROM sg_trips_by_county) INTO week_exists;
-    SELECT current_setting('myvars.date')::text NOT IN (SELECT DISTINCT date FROM sg_trips_days_included) INTO new_date;
+    SELECT current_setting('myvars.date')::text NOT IN (SELECT DISTINCT date FROM county_days_included) INTO new_date;
     SELECT to_char(current_setting('myvars.date')::date, 'IYYY-IW') INTO _year_week;
     
     IF new_date
@@ -78,7 +78,7 @@ BEGIN
         END IF;
     SELECT FORMAT(
         $inner$ 
-        INSERT INTO sg_trips_days_included
+        INSERT INTO county_days_included
         VALUES ('%s', '%s')
         $inner$, _year_week, current_setting('myvars.date')::text)
     INTO query;

--- a/social_distancing/trips_by_county.sql
+++ b/social_distancing/trips_by_county.sql
@@ -37,6 +37,34 @@ BEGIN
         INTO query;
         EXECUTE query;
     ELSE
-        RAISE NOTICE '% is already loaded !', _year_week;
+        SELECT FORMAT(
+            $inner$
+            UPDATE sg_trips_by_county.'%s' a
+            SET trips = trips + b.trips
+            FROM
+                (SELECT 
+                '%s' as year_week,
+                origin::text,
+                destination::text,
+                sum(counts) as trips
+                FROM (
+                    SELECT         
+                        LEFT(origin_census_block_group, 5) as origin,
+                        LEFT(desti.key, 5) as destination,
+                        desti.value::int as counts
+                    FROM social_distancing."%s",
+                        json_each_text(destination_cbgs) as desti
+                    WHERE LEFT(origin_census_block_group, 2) in (
+                        '36', '34', '09', '42', '25', '44' 
+                    )
+                    AND LEFT(desti.key, 2) in (
+                        '36', '34', '09', '42', '25', '44' )
+                ) a
+                GROUP BY origin, destination) b
+            JOIN b
+            ON a.year_week = b.year_week AND a.origin = b.origin AND a.destination = b.destination;
+        $inner$, current_setting('myvars.date'), current_setting('myvars.date'))
+        INTO query;
+        EXECUTE query;
     END IF;
 END $$

--- a/social_distancing/trips_by_county.sql
+++ b/social_distancing/trips_by_county.sql
@@ -8,7 +8,7 @@ DECLARE
 BEGIN
     SELECT to_char(current_setting('myvars.date')::date, 'IYYY-IW') NOT IN (SELECT DISTINCT year_week FROM sg_trips_by_county) INTO computed;
     SELECT to_char(current_setting('myvars.date')::date, 'IYYY-IW') INTO _year_week;
-
+    
     IF computed
     THEN
         SELECT FORMAT(

--- a/social_distancing/trips_by_county.sql
+++ b/social_distancing/trips_by_county.sql
@@ -24,6 +24,7 @@ BEGIN
 
         IF NOT week_exists
         THEN
+            RAISE NOTICE 'Loading % to a new week % ', current_setting('myvars.date')::text, _year_week;
             SELECT FORMAT(
                 $inner$
                 INSERT INTO sg_trips_by_county
@@ -50,6 +51,7 @@ BEGIN
             INTO query;
             EXECUTE query;
         ELSE
+            RAISE NOTICE 'Adding % to existing week % ', current_setting('myvars.date')::text, _year_week;
             SELECT FORMAT(
                 $inner$
                 WITH origin_dest AS 
@@ -85,6 +87,6 @@ BEGIN
             EXECUTE query;
         END IF;
     ELSE
-        RAISE NOTICE '% is already loaded !', current_setting('myvars.date')::text;
+        RAISE NOTICE '% is already loaded to records for week %', current_setting('myvars.date')::text, _year_week;
     END IF;
 END $$

--- a/social_distancing/trips_by_county.sql
+++ b/social_distancing/trips_by_county.sql
@@ -33,7 +33,7 @@ BEGIN
                 '36', '34', '09', '42', '25', '44' 
             )) a
             GROUP BY origin, destination;
-        $inner$, current_setting('myvars.date'), current_setting('myvars.date'))
+        $inner$, _year_week, current_setting('myvars.date'))
         INTO query;
         EXECUTE query;
     ELSE
@@ -54,7 +54,7 @@ BEGIN
                     '36', '34', '09', '42', '25', '44' )
             ) 
 
-            UPDATE sg_trips_by_county.'%s' a
+            UPDATE sg_trips_by_county a
             SET trips = trips + b.trips
             FROM
                 (SELECT 
@@ -67,7 +67,7 @@ BEGIN
             WHERE a.year_week = b.year_week 
             AND a.origin = b.origin 
             AND a.destination = b.destination;
-        $inner$, current_setting('myvars.date'), current_setting('myvars.date'), current_setting('myvars.date'))
+        $inner$, current_setting('myvars.date'), _year_week)
         INTO query;
         EXECUTE query;
     END IF;

--- a/social_distancing/trips_by_county.sql
+++ b/social_distancing/trips_by_county.sql
@@ -40,10 +40,10 @@ BEGIN
                 FROM social_distancing."%s",
                     json_each_text(destination_cbgs) as desti
                 WHERE LEFT(origin_census_block_group, 2) in (
-                    '36', '34', '09', '42', '25', '44' 
+                    '36', '34', '09', '42', '25', '44', '50', '33'
                 )
                 AND LEFT(desti.key, 2) in (
-                    '36', '34', '09', '42', '25', '44' 
+                    '36', '34', '09', '42', '25', '44', '50', '33'
                 )) a
                 GROUP BY origin, destination;
             $inner$, _year_week, current_setting('myvars.date'))
@@ -61,10 +61,10 @@ BEGIN
                     FROM social_distancing."%s",
                         json_each_text(destination_cbgs) as desti
                     WHERE LEFT(origin_census_block_group, 2) in (
-                        '36', '34', '09', '42', '25', '44' 
+                        '36', '34', '09', '42', '25', '44', '50', '33' 
                     )
                     AND LEFT(desti.key, 2) in (
-                        '36', '34', '09', '42', '25', '44' )
+                        '36', '34', '09', '42', '25', '44', '50', '33' )
                 ) 
 
                 UPDATE sg_trips_by_county a

--- a/social_distancing/trips_by_county.sql
+++ b/social_distancing/trips_by_county.sql
@@ -55,7 +55,7 @@ BEGIN
             ) 
 
             UPDATE sg_trips_by_county a
-            SET trips = trips + b.trips
+            SET trips = a.trips + b.trips
             FROM
                 (SELECT 
                 '%s' as year_week,

--- a/social_distancing/trips_by_county.sql
+++ b/social_distancing/trips_by_county.sql
@@ -6,8 +6,8 @@ DECLARE
     _year_week text;
     query text;
 BEGIN
-    SELECT to_char(current_setting('myvars.date'), 'IYYY-IW') NOT IN (SELECT DISTINCT year_week FROM sg_trips_by_county) INTO computed;
-    SELECT to_char(current_setting('myvars.date'), 'IYYY-IW') INTO _year_week;
+    SELECT to_char(current_setting('myvars.date')::date, 'IYYY-IW') NOT IN (SELECT DISTINCT year_week FROM sg_trips_by_county) INTO computed;
+    SELECT to_char(current_setting('myvars.date')::date, 'IYYY-IW') INTO _year_week;
 
     IF computed
     THEN

--- a/social_distancing/trips_by_county.sql
+++ b/social_distancing/trips_by_county.sql
@@ -1,0 +1,42 @@
+SET myvars.date TO :'DATE';
+
+DO $$
+DECLARE
+    computed boolean;
+    _year_week text;
+    query text;
+BEGIN
+    SELECT to_char(current_setting('myvars.date'), 'IYYY-IW') NOT IN (SELECT DISTINCT year_week FROM sg_trips_by_county) INTO computed;
+    SELECT to_char(current_setting('myvars.date'), 'IYYY-IW') INTO _year_week;
+
+    IF computed
+    THEN
+        SELECT FORMAT(
+            $inner$
+            INSERT INTO sg_trips_by_county
+            SELECT 
+            '%s' as year_week,
+            origin::text,
+            destination::text,
+            sum(counts) as trips
+            FROM (
+            SELECT         
+                LEFT(origin_census_block_group, 5) as origin,
+                LEFT(desti.key, 5) as destination,
+                desti.value::int as counts
+            FROM social_distancing."%s",
+                json_each_text(destination_cbgs) as desti
+            WHERE LEFT(origin_census_block_group, 2) in (
+                '36', '34', '09', '42', '25', '44' 
+            )
+            AND LEFT(desti.key, 2) in (
+                '36', '34', '09', '42', '25', '44' 
+            )) a
+            GROUP BY origin, destination;
+        $inner$, current_setting('myvars.date'), current_setting('myvars.date'))
+        INTO query;
+        EXECUTE query;
+    ELSE
+        RAISE NOTICE '% is already loaded !', _year_week;
+    END IF;
+END $$

--- a/social_distancing/trips_by_state.sql
+++ b/social_distancing/trips_by_state.sql
@@ -1,0 +1,139 @@
+SET myvars.date TO :'DATE';
+
+DO $$
+DECLARE
+    week_exists boolean;
+    new_date boolean;
+    _year_week text;
+    query text;
+
+BEGIN
+    SELECT to_char(current_setting('myvars.date')::date, 'IYYY-IW') NOT IN (SELECT DISTINCT year_week FROM sg_trips_by_state) INTO week_exists;
+    SELECT current_setting('myvars.date')::text NOT IN (SELECT DISTINCT date FROM state_days_included) INTO new_date;
+    SELECT to_char(current_setting('myvars.date')::date, 'IYYY-IW') INTO _year_week;
+    
+    IF new_date
+    THEN
+        IF week_exists
+        THEN
+            SELECT FORMAT(
+                $inner$
+                WITH pairs AS
+                    (
+                    SELECT 
+                    '%s' as year_week,
+                    origin::text,
+                    destination::text,
+                    sum(counts) as trips
+                    FROM (
+                    SELECT
+                        CASE
+                            WHEN  LEFT(origin_census_block_group, 5) 
+                                    IN ('36005', '36061', '36081', '36047', '36085')         
+                                THEN 'NYC'
+                            ELSE LEFT(origin_census_block_group, 2) 
+                        END as origin,
+                        CASE
+                            WHEN  LEFT(desti.key, 5) 
+                                    IN ('36005', '36061', '36081', '36047', '36085')         
+                                THEN 'NYC'
+                            ELSE LEFT(desti.key, 2)
+                        END as destination,
+                        desti.value::int as counts
+                    FROM social_distancing."%s",
+                        json_each_text(destination_cbgs) as desti
+                    WHERE LEFT(origin_census_block_group, 5) in (
+                        '36005', '36061', '36081', '36047', '36085' 
+                    )
+                    OR LEFT(desti.key, 5) in (
+                        '36005', '36061', '36081', '36047', '36085' 
+                    )) a
+                    GROUP BY origin, destination)
+
+                    INSERT INTO sg_trips_by_state
+                    SELECT
+                    a.year_week,
+                    a.origin as state,
+                    a.trips as to_nyc,
+                    b.trips as from_nyc,
+                    a.trips - b.trips as net_nyc,
+                    NULL as state_geom
+                    FROM pairs a
+                    JOIN pairs b
+                    ON a.origin=b.destination
+                    WHERE a.origin <> 'NYC';
+
+            $inner$, _year_week, current_setting('myvars.date'))
+            INTO query;
+            EXECUTE query;
+        ELSE
+            SELECT FORMAT(
+                $inner$
+                WITH pairs AS
+                    (
+                    SELECT 
+                    '%s' as year_week,
+                    origin::text,
+                    destination::text,
+                    sum(counts) as trips
+                    FROM (
+                    SELECT
+                        CASE
+                            WHEN  LEFT(origin_census_block_group, 5) 
+                                    IN ('36005', '36061', '36081', '36047', '36085')         
+                                THEN 'NYC'
+                            ELSE LEFT(origin_census_block_group, 2) 
+                        END as origin,
+                        CASE
+                            WHEN  LEFT(desti.key, 5) 
+                                    IN ('36005', '36061', '36081', '36047', '36085')         
+                                THEN 'NYC'
+                            ELSE LEFT(desti.key, 2)
+                        END as destination,
+                        desti.value::int as counts
+                    FROM social_distancing."%s",
+                        json_each_text(destination_cbgs) as desti
+                    WHERE LEFT(origin_census_block_group, 5) in (
+                        '36005', '36061', '36081', '36047', '36085' 
+                    )
+                    OR LEFT(desti.key, 5) in (
+                        '36005', '36061', '36081', '36047', '36085' 
+                    )) a
+                    GROUP BY origin, destination),
+                
+                daily AS (
+                    SELECT
+                    a.year_week,
+                    a.origin as state,
+                    a.trips as to_nyc,
+                    b.trips as from_nyc,
+                    a.trips - b.trips as net_nyc,
+                    NULL as state_geom
+                    FROM pairs a
+                    JOIN pairs b
+                    ON a.origin=b.destination
+                    WHERE a.origin <> 'NYC'
+                )
+
+                UPDATE sg_trips_by_state a
+                SET to_nyc = a.to_nyc + b.to_nyc,
+                    from_nyc = a.from_nyc + b.from_nyc,
+                    net_nyc = a.net_nyc + b.net_nyc
+                FROM daily b
+                WHERE a.year_week = b.year_week 
+                AND a.state = b.state;
+            $inner$, _year_week, current_setting('myvars.date'))
+            INTO query;
+            EXECUTE query;
+        END IF;
+    SELECT FORMAT(
+        $inner$ 
+        INSERT INTO state_days_included
+        VALUES ('%s', '%s')
+        $inner$, _year_week, current_setting('myvars.date')::text)
+    INTO query;
+    EXECUTE query;
+    ELSE
+        RAISE NOTICE '% is already loaded !', current_setting('myvars.date')::text;
+    END IF;
+END $$

--- a/social_distancing/trips_by_state.sql
+++ b/social_distancing/trips_by_state.sql
@@ -8,13 +8,21 @@ DECLARE
     query text;
 
 BEGIN
-    SELECT to_char(current_setting('myvars.date')::date, 'IYYY-IW') NOT IN (SELECT DISTINCT year_week FROM sg_trips_by_state) INTO week_exists;
+    SELECT to_char(current_setting('myvars.date')::date, 'IYYY-IW') IN (SELECT DISTINCT year_week FROM sg_trips_by_state) INTO week_exists;
     SELECT current_setting('myvars.date')::text NOT IN (SELECT DISTINCT date FROM state_days_included) INTO new_date;
     SELECT to_char(current_setting('myvars.date')::date, 'IYYY-IW') INTO _year_week;
     
     IF new_date
     THEN
-        IF week_exists
+        SELECT FORMAT(
+        $inner$ 
+        INSERT INTO state_days_included
+        VALUES ('%s', '%s')
+        $inner$, _year_week, current_setting('myvars.date')::text)
+        INTO query;
+        EXECUTE query;
+        
+        IF NOT week_exists
         THEN
             SELECT FORMAT(
                 $inner$
@@ -124,13 +132,6 @@ BEGIN
             INTO query;
             EXECUTE query;
         END IF;
-    SELECT FORMAT(
-        $inner$ 
-        INSERT INTO state_days_included
-        VALUES ('%s', '%s')
-        $inner$, _year_week, current_setting('myvars.date')::text)
-    INTO query;
-    EXECUTE query;
     ELSE
         RAISE NOTICE '% is already loaded !', current_setting('myvars.date')::text;
     END IF;

--- a/social_distancing/trips_by_state.sql
+++ b/social_distancing/trips_by_state.sql
@@ -56,8 +56,7 @@ BEGIN
                     a.origin as state,
                     a.trips as to_nyc,
                     b.trips as from_nyc,
-                    a.trips - b.trips as net_nyc,
-                    NULL as state_geom
+                    a.trips - b.trips as net_nyc
                     FROM pairs a
                     JOIN pairs b
                     ON a.origin=b.destination
@@ -107,8 +106,7 @@ BEGIN
                     a.origin as state,
                     a.trips as to_nyc,
                     b.trips as from_nyc,
-                    a.trips - b.trips as net_nyc,
-                    NULL as state_geom
+                    a.trips - b.trips as net_nyc
                     FROM pairs a
                     JOIN pairs b
                     ON a.origin=b.destination

--- a/social_distancing/trips_by_state.sql
+++ b/social_distancing/trips_by_state.sql
@@ -24,6 +24,7 @@ BEGIN
         
         IF NOT week_exists
         THEN
+            RAISE NOTICE 'Loading % to a new week % ', current_setting('myvars.date')::text, _year_week;
             SELECT FORMAT(
                 $inner$
                 WITH pairs AS
@@ -74,6 +75,7 @@ BEGIN
             INTO query;
             EXECUTE query;
         ELSE
+            RAISE NOTICE 'Adding % to existing week % ', current_setting('myvars.date')::text, _year_week;
             SELECT FORMAT(
                 $inner$
                 WITH pairs AS
@@ -133,6 +135,6 @@ BEGIN
             EXECUTE query;
         END IF;
     ELSE
-        RAISE NOTICE '% is already loaded !', current_setting('myvars.date')::text;
+        RAISE NOTICE '% is already loaded to records for week %', current_setting('myvars.date')::text, _year_week;
     END IF;
 END $$

--- a/trips_by_county.sh
+++ b/trips_by_county.sh
@@ -6,6 +6,8 @@ DATES=$(psql -q -At $SAFEGRAPH -c "\copy (
     WHERE table_schema = 'social_distancing'
 ) to STDOUT CSV")
 
+psql $SAFEGRAPH -f social_distancing/init_trips_by_county.sql
+
 for DATE in $(echo $DATES)
 do 
     max_bg_procs 20

--- a/trips_by_county.sh
+++ b/trips_by_county.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+source config.sh
+
+DATES=$(psql -q -At $SAFEGRAPH -c "\copy (
+     SELECT table_name FROM information_schema.tables 
+    WHERE table_schema = 'social_distancing'
+) to STDOUT CSV")
+
+for DATE in $(echo $DATES)
+do 
+    max_bg_procs 20
+    (
+         psql $SAFEGRAPH -v DATE=$DATE -f social_distancing/trips_by_county.sql
+    ) &
+done;

--- a/trips_by_county.sh
+++ b/trips_by_county.sh
@@ -10,7 +10,7 @@ psql $SAFEGRAPH -f social_distancing/init_trips_by_county.sql
 
 for DATE in $(echo $DATES)
 do 
-    max_bg_procs 20
+    max_bg_procs 1
     (
          psql $SAFEGRAPH -v DATE=$DATE -f social_distancing/trips_by_county.sql
     ) &

--- a/trips_by_state.sh
+++ b/trips_by_state.sh
@@ -10,7 +10,7 @@ psql $SAFEGRAPH -f social_distancing/init_trips_by_state.sql
 
 for DATE in $(echo $DATES)
 do 
-    max_bg_procs 20
+    max_bg_procs 1
     (
          psql $SAFEGRAPH -v DATE=$DATE -f social_distancing/trips_by_state.sql
     ) &

--- a/trips_by_state.sh
+++ b/trips_by_state.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+source config.sh
+
+DATES=$(psql -q -At $SAFEGRAPH -c "\copy (
+     SELECT table_name FROM information_schema.tables 
+    WHERE table_schema = 'social_distancing'
+) to STDOUT CSV")
+
+psql $SAFEGRAPH -f social_distancing/init_trips_by_state.sql
+
+for DATE in $(echo $DATES)
+do 
+    max_bg_procs 20
+    (
+         psql $SAFEGRAPH -v DATE=$DATE -f social_distancing/trips_by_state.sql
+    ) &
+done;


### PR DESCRIPTION
Creating sg_trips_by_county and sg_trips_by_state using a similar workflow as sg_outflow
If a year_week already exists in the table, the new day's trip count gets added to that record.

This PR does not yet include optional enhancement in #6 -- splitting by weekday/weekend