### PR TITLE
Switch to current quarter to work with  scheduled runners

### DIFF
--- a/recipes/daily_borough_poivisits_by_sector.py
+++ b/recipes/daily_borough_poivisits_by_sector.py
@@ -83,9 +83,9 @@ query = """
     """
     
 # Load the current quarter
-# quarters = get_quarter()
+quarters = get_quarter()
 
-quarters = PastQs
+# quarters = PastQs
 
 for year_qrtr, range in quarters.items():
     start = range[0]

--- a/recipes/daily_borough_poivisits_by_subsector.py
+++ b/recipes/daily_borough_poivisits_by_subsector.py
@@ -83,9 +83,9 @@ GROUP BY a.date_current,
 """
 
 # Load the current quarter
-# quarters = get_quarter()
+quarters = get_quarter()
 
-quarters = PastQs
+# quarters = PastQs
 
 for year_qrtr, range in quarters.items():
     start = range[0]

--- a/recipes/daily_nyc_poivisits.py
+++ b/recipes/daily_nyc_poivisits.py
@@ -81,9 +81,9 @@ LEFT JOIN (
 """
 
 # Load the current quarter
-# quarters = get_quarter()
+quarters = get_quarter()
 
-quarters = PastQs
+# quarters = PastQs
 
 for year_qrtr, range in quarters.items():
     start = range[0]

--- a/recipes/daily_zip_poivisits_by_sector.py
+++ b/recipes/daily_zip_poivisits_by_sector.py
@@ -87,9 +87,9 @@ GROUP BY a.date_current,
 """
 
 # Load the current quarter
-# quarters = get_quarter()
+quarters = get_quarter()
 
-quarters = PastQs
+# quarters = PastQs
 
 for year_qrtr, range in quarters.items():
     start = range[0]

--- a/recipes/daily_zip_poivisits_by_subsector.py
+++ b/recipes/daily_zip_poivisits_by_subsector.py
@@ -87,9 +87,9 @@ GROUP BY a.date_current,
 """
 
 # Load the current quarter
-# quarters = get_quarter()
+quarters = get_quarter()
 
-quarters = PastQs
+# quarters = PastQs
 
 for year_qrtr, range in quarters.items():
     start = range[0]

--- a/recipes/weekly_county_trips.py
+++ b/recipes/weekly_county_trips.py
@@ -54,9 +54,9 @@ GROUP BY EXTRACT(year from date_start),
 """
 
 # Load the current quarter
-# quarters = get_quarter()
+quarters = get_quarter()
 
-quarters = PastQs
+# quarters = PastQs
 
 for year_qrtr, range in quarters.items():
     start = range[0]

--- a/recipes/weekly_nyc_poivisits.py
+++ b/recipes/weekly_nyc_poivisits.py
@@ -93,9 +93,9 @@ GROUP BY EXTRACT(year from a.date_current),
 """
 
 # Load the current quarter
-# quarters = get_quarter()
+quarters = get_quarter()
 
-quarters = PastQs
+# quarters = PastQs
 
 for year_qrtr, range in quarters.items():
     start = range[0]

--- a/recipes/weekly_state_trips.py
+++ b/recipes/weekly_state_trips.py
@@ -71,9 +71,9 @@ SELECT
 """
 
 # Load the current quarter
-# quarters = get_quarter()
+quarters = get_quarter()
 
-quarters = PastQs
+# quarters = PastQs
 
 for year_qrtr, range in quarters.items():
     start = range[0]


### PR DESCRIPTION
We've already done a full run of the historical quarters for each dataset